### PR TITLE
[FIX]: Change replacer `Vendor` and `Package` with `Namespace`

### DIFF
--- a/canvas.yaml.stub
+++ b/canvas.yaml.stub
@@ -15,13 +15,13 @@ migration:
   prefix: ''
 
 console:
-  namespace: {{Vendor}}\{{Package}}\Console
+  namespace: {{Namespace}}\Console
 
 model:
-  namespace: {{Vendor}}\{{Package}}\Models
+  namespace: {{Namespace}}\Models
 
 provider:
-  namespace: {{Vendor}}\{{Vendor}}\Providers
+  namespace: {{Namespace}}\Providers
 
 testing:
-  namespace: {{Vendor}}\{{Vendor}}\Tests
+  namespace: {{Namespace}}\Tests

--- a/workbench/app/Providers/Filament/AdminPanelProvider.php.stub
+++ b/workbench/app/Providers/Filament/AdminPanelProvider.php.stub
@@ -55,7 +55,7 @@ class AdminPanelProvider extends PanelProvider
                 Authenticate::class,
             ])
             ->plugins([
-                \{{Vendor}}\{{Package}}\{{Package}}Plugin::make(),
+                \{{Namespace}}\{{Package}}Plugin::make(),
             ]);
     }
 }


### PR DESCRIPTION
The fix also solves the repeating `{{Vendor}}` replacer